### PR TITLE
Add paperclip-aperture to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Official repositories and resources from the Paperclip team.
 
 Extensions and integrations that add new capabilities to Paperclip.
 
+- [paperclip-aperture](https://github.com/tomismeta/paperclip-aperture) - Alternative Focus view for Paperclip that deterministically ranks approvals, issue activity, and other human-facing events into now, next, and ambient.
 - [paperclip-plugin-chat](https://github.com/webprismdevin/paperclip-plugin-chat) - Interactive AI chat copilot for managing tasks, agents, and workspaces.
 - [paperclip-plugin-discord](https://github.com/mvanhorn/paperclip-plugin-discord) - Bidirectional Discord integration: notifications, slash commands, and community intelligence.
 - [paperclip-plugin-github-issues](https://github.com/mvanhorn/paperclip-plugin-github-issues) - Bidirectional GitHub Issues sync for Paperclip.


### PR DESCRIPTION
## Summary
- add `paperclip-aperture` to the `Plugins` section
- describe it as an alternative Focus view for Paperclip
- keep the list alphabetically ordered

## Entry
`paperclip-aperture` - Alternative Focus view for Paperclip that deterministically ranks approvals, issue activity, and other human-facing events into now, next, and ambient.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new plugin option to the list: `paperclip-aperture`, an alternative Focus view that deterministically ranks approvals, issue activity, and other events into prioritized categories (now/next/ambient).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->