### PR TITLE
Add paperclip-plugin-acp to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Official repositories and resources from the Paperclip team.
 Extensions and integrations that add new capabilities to Paperclip.
 
 - [paperclip-aperture](https://github.com/tomismeta/paperclip-aperture) - Alternative Focus view for Paperclip that deterministically ranks approvals, issue activity, and other human-facing events into now, next, and ambient.
+- [paperclip-plugin-acp](https://github.com/mvanhorn/paperclip-plugin-acp) - ACP runtime plugin that runs Claude Code, Codex, and Gemini CLI from any chat platform.
 - [paperclip-plugin-chat](https://github.com/webprismdevin/paperclip-plugin-chat) - Interactive AI chat copilot for managing tasks, agents, and workspaces.
 - [paperclip-plugin-discord](https://github.com/mvanhorn/paperclip-plugin-discord) - Bidirectional Discord integration: notifications, slash commands, and community intelligence.
 - [paperclip-plugin-github-issues](https://github.com/mvanhorn/paperclip-plugin-github-issues) - Bidirectional GitHub Issues sync for Paperclip.


### PR DESCRIPTION
Adds [paperclip-plugin-acp](https://github.com/mvanhorn/paperclip-plugin-acp) to the Plugins section. ACP (Agent Client Protocol) runtime plugin that runs Claude Code, Codex, and Gemini CLI from any chat platform connected to Paperclip.

Inserted alphabetically between `paperclip-aperture` and `paperclip-plugin-chat`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin documentation with a new ACP runtime plugin entry enabling Claude Code, Codex, and Gemini CLI integration across chat platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->