### PR TITLE
Add paperclip-plugin-avp — trust & reputation layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Extensions and integrations that add new capabilities to Paperclip.
 
 - [paperclip-aperture](https://github.com/tomismeta/paperclip-aperture) - Alternative Focus view for Paperclip that deterministically ranks approvals, issue activity, and other human-facing events into now, next, and ambient.
 - [paperclip-plugin-acp](https://github.com/mvanhorn/paperclip-plugin-acp) - ACP runtime plugin that runs Claude Code, Codex, and Gemini CLI from any chat platform.
+- [paperclip-plugin-avp](https://github.com/creatorrmode-lead/paperclip-plugin-avp) — Trust and reputation layer via Agent Veil Protocol. DID identity, EigenTrust reputation, signed attestations. Adds trust gates before delegation and team reputation evaluation. [npm](https://www.npmjs.com/package/paperclip-plugin-avp)
 - [paperclip-plugin-chat](https://github.com/webprismdevin/paperclip-plugin-chat) - Interactive AI chat copilot for managing tasks, agents, and workspaces.
 - [paperclip-plugin-company-wizard](https://github.com/yesterday-ai/paperclip-plugin-company-wizard) - AI-powered company setup assistant with presets.
 - [paperclip-plugin-discord](https://github.com/mvanhorn/paperclip-plugin-discord) - Bidirectional Discord integration: notifications, slash commands, and community intelligence.


### PR DESCRIPTION
Adds paperclip-plugin-avp — native Paperclip plugin for agent trust & reputation.

- 5 tools: reputation check, delegation gate, attestation logging, team evaluation, heartbeat reports
- Built per PLUGIN_SPEC.md
- Published on npm: paperclip-plugin-avp
- 24 unit tests, MIT license

Install: `paperclipai plugin install paperclip-plugin-avp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new plugin `paperclip-plugin-avp` to the plugins list, featuring a trust and reputation layer with Agent Veil Protocol integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->