### PR TITLE
Add paperclip-plugin-writbase to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Extensions and integrations that add new capabilities to Paperclip.
 - [paperclip-plugin-discord](https://github.com/mvanhorn/paperclip-plugin-discord) - Bidirectional Discord integration: notifications, slash commands, and community intelligence.
 - [paperclip-plugin-github-issues](https://github.com/mvanhorn/paperclip-plugin-github-issues) - Bidirectional GitHub Issues sync for Paperclip.
 - [paperclip-plugin-slack](https://github.com/mvanhorn/paperclip-plugin-slack) - Slack notifications plugin — posts to Slack when issues are created, completed, or need approval.
-- [paperclip-plugin-telegram](https://github.com/mvanhorn/paperclip-plugin-telegram) - Telegram notifications plugin — posts to Telegram when issues are created, completed, or need approval. 
+- [paperclip-plugin-telegram](https://github.com/mvanhorn/paperclip-plugin-telegram) - Telegram notifications plugin — posts to Telegram when issues are created, completed, or need approval.
+- [paperclip-plugin-writbase](https://github.com/Writbase/paperclip-plugin-writbase) - Bidirectional sync between Paperclip issues and WritBase tasks with webhook-driven updates and periodic reconciliation.
 
 ## Tools & Utilities
 


### PR DESCRIPTION
Adds [paperclip-plugin-writbase](https://github.com/Writbase/paperclip-plugin-writbase) to the Plugins section.

Bidirectional sync between Paperclip issues and WritBase tasks with webhook-driven updates and periodic reconciliation. Inserted alphabetically at the end of the Plugins list (after paperclip-plugin-telegram).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added WritBase plugin entry, enabling bidirectional synchronization between Paperclip and WritBase with webhook-driven real-time updates and periodic reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->