### PR TITLE
Add paperclip-live-analytics-plugin to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Official repositories and resources from the Paperclip team.
 Extensions and integrations that add new capabilities to Paperclip.
 
 - [paperclip-aperture](https://github.com/tomismeta/paperclip-aperture) - Alternative Focus view for Paperclip that deterministically ranks approvals, issue activity, and other human-facing events into now, next, and ambient.
+- [paperclip-live-analytics-plugin](https://github.com/Agent-Analytics/paperclip-live-analytics-plugin) - Live visitor map, dashboard widget, and settings page for viewing Agent Analytics inside Paperclip.
 - [paperclip-plugin-acp](https://github.com/mvanhorn/paperclip-plugin-acp) - ACP runtime plugin that runs Claude Code, Codex, and Gemini CLI from any chat platform.
 - [paperclip-plugin-avp](https://github.com/creatorrmode-lead/paperclip-plugin-avp) — Trust and reputation layer via Agent Veil Protocol. DID identity, EigenTrust reputation, signed attestations. Adds trust gates before delegation and team reputation evaluation. [npm](https://www.npmjs.com/package/paperclip-plugin-avp)
 - [paperclip-plugin-chat](https://github.com/webprismdevin/paperclip-plugin-chat) - Interactive AI chat copilot for managing tasks, agents, and workspaces.


### PR DESCRIPTION
## Summary
- add Agent Analytics Live to the Plugins section
- link to the public repository under the Agent-Analytics org
- describe the Paperclip live map, dashboard widget, and settings page in one sentence

## Why
This plugin is public, maintained, and directly adds live analytics capabilities inside Paperclip.