### PR TITLE
Add Paperclip Troubleshooting Guide link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Bots, bundles, and helper tools for the Paperclip ecosystem.
 Guides, books, and learning materials about Paperclip.
 
 - [Headcount Zero](https://github.com/AnthonyDavidAdams/zero-employee-company-book) - *Headcount Zero: How to Build an AI-Run Company with Paperclip* — an open-source book.
+- *   [Paperclip Troubleshooting Guide](https://github.com/paperclip-ai/paperclip/blob/main/docs/guides/troubleshooting.md) - Common issues, FAQs, and solutions for Paperclip.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Bots, bundles, and helper tools for the Paperclip ecosystem.
 Guides, books, and learning materials about Paperclip.
 
 - [Headcount Zero](https://github.com/AnthonyDavidAdams/zero-employee-company-book) - *Headcount Zero: How to Build an AI-Run Company with Paperclip* — an open-source book.
-- *   [Paperclip Troubleshooting Guide](https://github.com/paperclip-ai/paperclip/blob/main/docs/guides/troubleshooting.md) - Common issues, FAQs, and solutions for Paperclip.
+- [Paperclip Troubleshooting Guide](https://github.com/paperclipai/paperclip/blob/main/docs/guides/troubleshooting.md) - Common issues, FAQs, and solutions for Paperclip.
 
 ---
 


### PR DESCRIPTION
Added a link to the Paperclip Troubleshooting Guide for common issues and FAQs.
## What this adds
- Troubleshooting guide link under "Resources" section
- Guide covers common issues, FAQs, and solutions for Paperclip users

## Why it's useful
- Currently no troubleshooting resource in the list
- Helps new users debug common problems

## Related
- Part of Paperclip's official documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Troubleshooting Guide link to the README, giving users quick access to common issues, FAQs, and solutions.
  * Clarified that this change only adds a resource link; no other README content or public-facing declarations were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->