### PR TITLE
Add obsidian-paperclip to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Official repositories and resources from the Paperclip team.
 
 Extensions and integrations that add new capabilities to Paperclip.
 
-- [obsidian-paperclip](https://github.com/istib/obsidian-paperclip) - Obsidian plugin for browsing, commenting on, and assigning Paperclip issues to AI agents without leaving your notes.
+- [obsidian-paperclip](https://github.com/istib/obsidian-paperclip) - Obsidian plugin to browse, comment on, and assign Paperclip issues to AI agents.
 - [paperclip-aperture](https://github.com/tomismeta/paperclip-aperture) - Alternative Focus view for Paperclip that deterministically ranks approvals, issue activity, and other human-facing events into now, next, and ambient.
 - [paperclip-plugin-acp](https://github.com/mvanhorn/paperclip-plugin-acp) - ACP runtime plugin that runs Claude Code, Codex, and Gemini CLI from any chat platform.
 - [paperclip-plugin-avp](https://github.com/creatorrmode-lead/paperclip-plugin-avp) — Trust and reputation layer via Agent Veil Protocol. DID identity, EigenTrust reputation, signed attestations. Adds trust gates before delegation and team reputation evaluation. [npm](https://www.npmjs.com/package/paperclip-plugin-avp)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Official repositories and resources from the Paperclip team.
 
 Extensions and integrations that add new capabilities to Paperclip.
 
+- [obsidian-paperclip](https://github.com/istib/obsidian-paperclip) - Obsidian plugin for browsing, commenting on, and assigning Paperclip issues to AI agents without leaving your notes.
 - [paperclip-aperture](https://github.com/tomismeta/paperclip-aperture) - Alternative Focus view for Paperclip that deterministically ranks approvals, issue activity, and other human-facing events into now, next, and ambient.
 - [paperclip-plugin-acp](https://github.com/mvanhorn/paperclip-plugin-acp) - ACP runtime plugin that runs Claude Code, Codex, and Gemini CLI from any chat platform.
 - [paperclip-plugin-avp](https://github.com/creatorrmode-lead/paperclip-plugin-avp) — Trust and reputation layer via Agent Veil Protocol. DID identity, EigenTrust reputation, signed attestations. Adds trust gates before delegation and team reputation evaluation. [npm](https://www.npmjs.com/package/paperclip-plugin-avp)


### PR DESCRIPTION
## Summary
- add obsidian-paperclip to the Plugins section
- describe the Obsidian integration for browsing, commenting on, and assigning Paperclip issues

## Testing
- not applicable (README-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "obsidian-paperclip" to the Plugins list in the documentation—an Obsidian plugin that lets you browse Paperclip issues, add comments, and assign issues to AI agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->