### PR TITLE
Add paperclip-plugin-hindsight — persistent memory for Paperclip agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Extensions and integrations that add new capabilities to Paperclip.
 - [paperclip-plugin-slack](https://github.com/mvanhorn/paperclip-plugin-slack) - Slack notifications plugin — posts to Slack when issues are created, completed, or need approval.
 - [paperclip-plugin-telegram](https://github.com/mvanhorn/paperclip-plugin-telegram) - Telegram notifications plugin — posts to Telegram when issues are created, completed, or need approval.
 - [paperclip-plugin-writbase](https://github.com/Writbase/paperclip-plugin-writbase) - Bidirectional sync between Paperclip issues and WritBase tasks with webhook-driven updates and periodic reconciliation.
+- [paperclip-plugin-hindsight](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/paperclip-plugin) - Persistent long-term memory for Paperclip agents — recall before every heartbeat, retain after every run. [npm](https://www.npmjs.com/package/paperclip-plugin-hindsight)
 
 ## Tools & Utilities
 


### PR DESCRIPTION
## What

Adds [paperclip-plugin-hindsight](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/paperclip-plugin) to the Plugins section.

## What it does

Gives every Paperclip agent persistent long-term memory via [Hindsight](https://github.com/vectorize-io/hindsight):

- **Before each run** — recalls relevant memories from past runs and caches them for the agent
- **After each run** — automatically retains agent output to Hindsight
- **Agent tools** — `hindsight_recall` and `hindsight_retain` tools callable mid-run

Install with:
```bash
pnpm paperclipai plugin install paperclip-plugin-hindsight
```

Works with Hindsight self-hosted or [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `paperclip-plugin-hindsight` to the plugins list, a plugin that provides persistent long-term memory capabilities for Paperclip agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->