### PR TITLE
Add mnemopay-paperclip-plugin — Agent FICO scoring and memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Extensions and integrations that add new capabilities to Paperclip.
 - [paperclip-plugin-telegram](https://github.com/mvanhorn/paperclip-plugin-telegram) - Telegram notifications plugin — posts to Telegram when issues are created, completed, or need approval.
 - [paperclip-plugin-writbase](https://github.com/Writbase/paperclip-plugin-writbase) - Bidirectional sync between Paperclip issues and WritBase tasks with webhook-driven updates and periodic reconciliation.
 - [paperclip-plugin-hindsight](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/paperclip-plugin) - Persistent long-term memory for Paperclip agents — recall before every heartbeat, retain after every run. [npm](https://www.npmjs.com/package/paperclip-plugin-hindsight)
+- [mnemopay-paperclip-plugin](https://github.com/mnemopay/mnemopay-paperclip-plugin) - Agent FICO behavioral scoring (300-850) and persistent memory for Paperclip agents. Real credit-score components: payment history, utilization, account age, diversity, fraud record. Optional MnemoPay server integration for semantic recall. FICO gating blocks compromised agents. [npm](https://www.npmjs.com/package/mnemopay-paperclip-plugin)
 
 ## Tools & Utilities
 


### PR DESCRIPTION
## What this adds

[mnemopay-paperclip-plugin](https://github.com/mnemopay/mnemopay-paperclip-plugin) — Agent FICO behavioral scoring (300-850) and persistent memory for Paperclip agents.

**npm:** `npm install mnemopay-paperclip-plugin`

### Features
- **Agent FICO score** computed from real execution history using five weighted components (payment history, credit utilization, account age, behavior diversity, fraud record) — same methodology as consumer credit scoring, adapted for AI agents
- **Semantic memory recall** via optional MnemoPay server integration — agents recall relevant context before each execution, store outcomes after
- **FICO gating** — optionally block agents whose score drops below a threshold (useful after detected manipulation or repeated failures)
- **Zero-infra mode** — FICO scoring works locally with no server required; plug in a MnemoPay MCP server to enable full memory persistence

### Why it's useful
Paperclip's Memory & Knowledge feature is listed as roadmap. This fills that gap today with a behavioral accountability layer that improves as agents execute more tasks.

Built on [@mnemopay/sdk](https://www.npmjs.com/package/@mnemopay/sdk) (Apache 2.0, 400K+ npm downloads).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the new mnemopay-paperclip-plugin, which provides FICO behavioral scoring (300–850) and persistent memory capabilities for Paperclip agents, including links to its GitHub repository and npm package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->