### PR TITLE
Remove broken Paperclip Troubleshooting Guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Bots, bundles, and helper tools for the Paperclip ecosystem.
 Guides, books, and learning materials about Paperclip.
 
 - [Headcount Zero](https://github.com/AnthonyDavidAdams/zero-employee-company-book) - *Headcount Zero: How to Build an AI-Run Company with Paperclip* — an open-source book.
-- [Paperclip Troubleshooting Guide](https://github.com/paperclipai/paperclip/blob/main/docs/guides/troubleshooting.md) - Common issues, FAQs, and solutions for Paperclip.
 
 ---
 


### PR DESCRIPTION
Closes #19.

The URL referenced in the Resources section of the README,
`https://github.com/paperclipai/paperclipai/blob/main/docs/guides/troubleshooting.md`, returns a 404. Browsing `docs/guides/` in the upstream `paperclipai/paperclip` repository shows only `board-operator/`, `agent-developer/`, `execution-policy.md`, and `openclaw-docker-setup.md`; searching the whole repo for `troubleshoot` surfaces incidental mentions inside deploy and agents-runtime docs but no dedicated troubleshooting guide to redirect to.

Since there is no stable replacement target today, this PR takes the issue's second suggested option and removes the stale entry so the Resources section stops pointing at a broken page. If an official troubleshooting guide lands upstream later, a follow-up PR can add it back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Paperclip Troubleshooting Guide from the Resources section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->