### PR TITLE
Add new plugin Agent Pixels to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Official repositories and resources from the Paperclip team.
 
 Extensions and integrations that add new capabilities to Paperclip.
 
-- [Agent Pixels](https://github.com/gcampton/Agent-Pixels) - Pixel Agents (vscode extension) running in Paperclip, more models, more rooms, security cam access.
+- [Agent Pixels](https://github.com/gcampton/Agent-Pixels) - Pixel Agents for Paperclip (adapted from VS Code) with custom behaviors (idling, researching, coding), 70+ models, more rooms, and security cam access.
 - [obsidian-paperclip](https://github.com/istib/obsidian-paperclip) - Obsidian plugin to browse, comment on, and assign Paperclip issues to AI agents.
 - [paperclip-aperture](https://github.com/tomismeta/paperclip-aperture) - Alternative Focus view for Paperclip that deterministically ranks approvals, issue activity, and other human-facing events into now, next, and ambient.
 - [paperclip-live-analytics-plugin](https://github.com/Agent-Analytics/paperclip-live-analytics-plugin) - Live visitor map, dashboard widget, and settings page for viewing Agent Analytics inside Paperclip.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Official repositories and resources from the Paperclip team.
 
 Extensions and integrations that add new capabilities to Paperclip.
 
+- [Agent Pixels](https://github.com/gcampton/Agent-Pixels) - Pixel Agents (vscode extension) running in Paperclip, more models, more rooms, security cam access.
 - [obsidian-paperclip](https://github.com/istib/obsidian-paperclip) - Obsidian plugin to browse, comment on, and assign Paperclip issues to AI agents.
 - [paperclip-aperture](https://github.com/tomismeta/paperclip-aperture) - Alternative Focus view for Paperclip that deterministically ranks approvals, issue activity, and other human-facing events into now, next, and ambient.
 - [paperclip-live-analytics-plugin](https://github.com/Agent-Analytics/paperclip-live-analytics-plugin) - Live visitor map, dashboard widget, and settings page for viewing Agent Analytics inside Paperclip.


### PR DESCRIPTION
Agent Pixels is an adaptation of Pablo De Lucca's VSCode extension. With more rooms, 70+ more models, more furniture + Featuring Dotta. Agents idle when not working, and sit and read if researching, or type at a PC when coding. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Agent Pixels" to the Plugins section of the README with a link and description of Pixel Agents for Paperclip (custom behaviors, increased model capacity, expanded room support, and security camera access).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->