### PR TITLE
Add paperclip-plugin-linear to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Extensions and integrations that add new capabilities to Paperclip.
 - [paperclip-plugin-company-wizard](https://github.com/yesterday-ai/paperclip-plugin-company-wizard) - AI-powered company setup assistant with presets.
 - [paperclip-plugin-discord](https://github.com/mvanhorn/paperclip-plugin-discord) - Bidirectional Discord integration: notifications, slash commands, and community intelligence.
 - [paperclip-plugin-github-issues](https://github.com/mvanhorn/paperclip-plugin-github-issues) - Bidirectional GitHub Issues sync for Paperclip.
+- [paperclip-plugin-linear](https://github.com/Oldharlem/paperclip-linear-plugin) - Bidirectional Linear sync for Paperclip — issue sync, comments, status mirroring, webhooks, and an agent tool. [npm](https://www.npmjs.com/package/@oldharlem/paperclip-plugin-linear)
 - [paperclip-plugin-slack](https://github.com/mvanhorn/paperclip-plugin-slack) - Slack notifications plugin — posts to Slack when issues are created, completed, or need approval.
 - [paperclip-plugin-telegram](https://github.com/mvanhorn/paperclip-plugin-telegram) - Telegram notifications plugin — posts to Telegram when issues are created, completed, or need approval.
 - [paperclip-plugin-writbase](https://github.com/Writbase/paperclip-plugin-writbase) - Bidirectional sync between Paperclip issues and WritBase tasks with webhook-driven updates and periodic reconciliation.


### PR DESCRIPTION
## Summary

Adds [`paperclip-plugin-linear`](https://github.com/Oldharlem/paperclip-linear-plugin) to the **Plugins** section.

It's a bidirectional Linear ↔ Paperclip connector:
- Issue, comment, and status sync (both directions)
- Linear webhook ingestion
- Agent tool surface so Paperclip agents can read/update Linear directly
- Published on npm as [`@oldharlem/paperclip-plugin-linear`](https://www.npmjs.com/package/@oldharlem/paperclip-plugin-linear)

## Checklist

- [x] One addition per PR
- [x] Alphabetically ordered (between `paperclip-plugin-github-issues` and `paperclip-plugin-slack`)
- [x] Public repo, MIT licensed, recent activity
- [x] Description starts with a capital, ends with a period
- [x] Links verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new entry for the "paperclip-plugin-linear" plugin, including repository and npm links.
  * Describes bidirectional Linear sync features: issue and comment synchronization, status mirroring, webhook support, and an agent tool for automation and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->