### PR TITLE
Update README - add paperclip-plugin-company-wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Extensions and integrations that add new capabilities to Paperclip.
 - [paperclip-plugin-acp](https://github.com/mvanhorn/paperclip-plugin-acp) - ACP runtime plugin that runs Claude Code, Codex, and Gemini CLI from any chat platform.
 - [paperclip-plugin-avp](https://github.com/creatorrmode-lead/paperclip-plugin-avp) — Trust and reputation layer via Agent Veil Protocol. DID identity, EigenTrust reputation, signed attestations. Adds trust gates before delegation and team reputation evaluation. [npm](https://www.npmjs.com/package/paperclip-plugin-avp)
 - [paperclip-plugin-chat](https://github.com/webprismdevin/paperclip-plugin-chat) - Interactive AI chat copilot for managing tasks, agents, and workspaces.
-- [paperclip-plugin-company-wizard](https://github.com/yesterday-ai/paperclip-plugin-company-wizard) - AI-powered company setup assistant with presets.
+- [paperclip-plugin-company-wizard](https://github.com/starlein/paperclip-plugin-company-wizard) - AI-powered company setup assistant with presets. [old version](https://github.com/Yesterday-AI/paperclip-plugin-company-wizard)
 - [paperclip-plugin-discord](https://github.com/mvanhorn/paperclip-plugin-discord) - Bidirectional Discord integration: notifications, slash commands, and community intelligence.
 - [paperclip-plugin-github-issues](https://github.com/mvanhorn/paperclip-plugin-github-issues) - Bidirectional GitHub Issues sync for Paperclip.
 - [paperclip-plugin-linear](https://github.com/Oldharlem/paperclip-linear-plugin) - Bidirectional Linear sync for Paperclip — issue sync, comments, status mirroring, webhooks, and an agent tool. [npm](https://www.npmjs.com/package/@oldharlem/paperclip-plugin-linear)


### PR DESCRIPTION
Link to new version of paperclip-plugin-company-wizard that works with latest paperclip version.

This pull request updates the `README.md` to clarify the source of the `paperclip-plugin-company-wizard` extension. The entry now points to a new GitHub repository and provides a link to the old version for reference.

Repository and documentation update:

* Updated the `paperclip-plugin-company-wizard` entry to use the new repository at `starlein/paperclip-plugin-company-wizard` and added a link to the old version at `Yesterday-AI/paperclip-plugin-company-wizard` for historical reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin references in the README to reflect current version sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->