### PR TITLE
Add paperclip-plugin-google-chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Extensions and integrations that add new capabilities to Paperclip.
 - [paperclip-plugin-company-wizard](https://github.com/yesterday-ai/paperclip-plugin-company-wizard) - AI-powered company setup assistant with presets.
 - [paperclip-plugin-discord](https://github.com/mvanhorn/paperclip-plugin-discord) - Bidirectional Discord integration: notifications, slash commands, and community intelligence.
 - [paperclip-plugin-github-issues](https://github.com/mvanhorn/paperclip-plugin-github-issues) - Bidirectional GitHub Issues sync for Paperclip.
+- [paperclip-plugin-google-chat](https://github.com/measured-assets/paperclip-plugin-google-chat) - Bidirectional Google Chat integration: posts issue, approval, and agent-failure notifications to spaces and drives Paperclip from Chat slash commands. [npm](https://www.npmjs.com/package/paperclip-plugin-google-chat)
 - [paperclip-plugin-linear](https://github.com/Oldharlem/paperclip-linear-plugin) - Bidirectional Linear sync for Paperclip — issue sync, comments, status mirroring, webhooks, and an agent tool. [npm](https://www.npmjs.com/package/@oldharlem/paperclip-plugin-linear)
 - [paperclip-plugin-slack](https://github.com/mvanhorn/paperclip-plugin-slack) - Slack notifications plugin — posts to Slack when issues are created, completed, or need approval.
 - [paperclip-plugin-telegram](https://github.com/mvanhorn/paperclip-plugin-telegram) - Telegram notifications plugin — posts to Telegram when issues are created, completed, or need approval.


### PR DESCRIPTION
Adds [`paperclip-plugin-google-chat`](https://github.com/measured-assets/paperclip-plugin-google-chat) to the Plugins list (alphabetically, after `paperclip-plugin-github-issues`).

A bidirectional Google Chat connector built on the first-party plugin SDK (`apiVersion 1`, MIT):

- **Outbound** — `events.subscribe` posts issue / approval / agent-failure notifications to Google Chat spaces (via incoming webhooks); agent tools `post_to_google_chat`, `escalate_to_human`, `send_briefing`; optional daily digest.
- **Inbound** — `webhooks.receive` routes slash commands (`/status`, `/issues`, `/agents`, `/report`, `/objective`, `/help`) with space + user allowlists.
- Chat webhook URLs are held as Paperclip secret refs (`secrets.read-ref`), never plaintext.

Published on npm: https://www.npmjs.com/package/paperclip-plugin-google-chat

It fills the one gap in the chat connectors (Slack/Discord/Telegram exist; Google Chat did not).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Plugins list in the README with a new entry for Google Chat integration, including a brief description and package link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->