### PR TITLE
Add file-access-manager to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Extensions and integrations that add new capabilities to Paperclip.
 - [paperclip-plugin-telegram](https://github.com/mvanhorn/paperclip-plugin-telegram) - Telegram notifications plugin — posts to Telegram when issues are created, completed, or need approval.
 - [paperclip-plugin-writbase](https://github.com/Writbase/paperclip-plugin-writbase) - Bidirectional sync between Paperclip issues and WritBase tasks with webhook-driven updates and periodic reconciliation.
 - [paperclip-plugin-hindsight](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/paperclip-plugin) - Persistent long-term memory for Paperclip agents — recall before every heartbeat, retain after every run. [npm](https://www.npmjs.com/package/paperclip-plugin-hindsight)
+- [file-access-manager](https://github.com/marospekarik/paperclip-hermes-file-access-manager) — Kernel-enforced filesystem sandboxing for Hermes Agent profiles. Visual permission editor inside Paperclip; denied paths don't exist in the container. By Ordillect.
 
 ## Tools & Utilities
 


### PR DESCRIPTION
## Add file-access-manager to Plugins

Adds [file-access-manager](https://github.com/marospekarik/paperclip-hermes-file-access-manager) to the Plugins section.

### What it is

A Paperclip UI plugin that gives every Hermes Agent profile a visual filesystem sandbox. You browse the directory tree, set each path to Read/Write, Read-Only, or Denied, and save. The plugin writes the profile's `file_access` config — Hermes translates that into Docker bind mounts.

### Why it belongs in awesome-paperclip

- Built on the Paperclip plugin SDK (`@paperclipai/plugin-sdk`)
- Registers as both a company settings page and a per-agent detail tab
- Directly addresses a real gap in the Hermes + Paperclip stack: the built-in `file_access` config only guards file tools, not the agent's shell
- MIT license, open source, actively maintained

### Key features

- Three states: Read/Write, Read-Only, Denied
- Docker bind-mount enforcement (kernel-level, not config flags)
- Inheritance: folder settings inherit downward, deeper settings override
- Sensitive-path masking: `.ssh`, `.gnupg`, `.env` auto-denied when granting broad paths
- One-click Save & Apply
- REST API surface (`GET/POST /agents/:agentId/file-access`, `GET /scan`)

### Install

```bash
paperclipai plugin install --local "$PWD"
```

Built by Ordillect. MIT license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `file-access-manager` to the Plugins list, describing its filesystem sandboxing capabilities for Hermes Agent profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->