### PR TITLE
Add GSC — Git Security Checker (SAST as a Paperclip security agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Bots, bundles, and helper tools for the Paperclip ecosystem.
 - [oh-my-paperclip](https://github.com/gsxdsm/oh-my-paperclip) - The go-to bundle of Paperclip plugins.
 - [paperclip-discord-bot](https://github.com/rekon307/paperclip-discord-bot) - Discord bot for the Paperclip community — GitHub OAuth contributor roles and daily AI summaries.
 - [paperclip-mcp](https://github.com/wizarck/paperclip-mcp) - MCP server that exposes the Paperclip REST API as tools for Claude Code and Claude Desktop.
+- [GSC — Git Security Checker](https://github.com/poliakarmai/gsc) - SAST as a Paperclip security agent: connect the GSC MCP server (`scan_repo`/`list_findings`/`verify_finding`/`get_finding`/`list_detectors`) through the MCP Tool Gateway (`local_stdio` or `mcp_remote`) and hire any agent (Claude Code, Codex, Hermes) as a Security Engineer. Ships a `gsc-security-review` skill.
 
 ## Resources
 


### PR DESCRIPTION
## What

Add [GSC (Git Security Checker)](https://github.com/poliakarmai/gsc) to **Tools & Utilities**.

GSC is a SAST platform that plugs into Paperclip through the **MCP Tool Gateway** — connect the GSC MCP server (`scan_repo` / `list_findings` / `verify_finding` / `get_finding` / `list_detectors`) via `local_stdio` or `mcp_remote`, then hire any agent (Claude Code, Codex, Hermes) as a Security Engineer. Ships a `gsc-security-review` skill.

## Why

- 5 governed MCP tools, transport `local_stdio` (subprocess) or `mcp_remote` (HTTP)
- Full security workflow: scan → triage → verify PoC → fix → PR
- Integration guide + skill live in gsc-core `docs/integrations/paperclip/`
- End-to-end verified: `initialize → tools/call scan_repo` returns findings

## Checklist

- [x] Added to Tools & Utilities (alongside paperclip-mcp, another MCP integration)
- [x] Link points to a public repo
- [x] One-line description, no marketing fluff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Git Security Checker (GSC) to the Tools & Utilities section.
  * Documented its security review capabilities and integration with Paperclip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->