### PR TITLE
Add bulk-model-switcher to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Official repositories and resources from the Paperclip team.
 Extensions and integrations that add new capabilities to Paperclip.
 
 - [Agent Pixels](https://github.com/gcampton/Agent-Pixels) - Pixel Agents for Paperclip (adapted from VS Code) with custom behaviors (idling, researching, coding), 70+ models, more rooms, and security cam access.
+- [bulk-model-switcher](https://github.com/herrhelms/bulk-model-switcher) - Select one or more agents of your org at once and set their model and reasoning effort in one action.
 - [obsidian-paperclip](https://github.com/istib/obsidian-paperclip) - Obsidian plugin to browse, comment on, and assign Paperclip issues to AI agents.
 - [paperclip-aperture](https://github.com/tomismeta/paperclip-aperture) - Alternative Focus view for Paperclip that deterministically ranks approvals, issue activity, and other human-facing events into now, next, and ambient.
 - [paperclip-live-analytics-plugin](https://github.com/Agent-Analytics/paperclip-live-analytics-plugin) - Live visitor map, dashboard widget, and settings page for viewing Agent Analytics inside Paperclip.


### PR DESCRIPTION
A paperclip plugin to quickly multi-select some or all agents in your org to modify their model and resoning efforts. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `bulk-model-switcher` plugin to the Plugins section.
  * Included a link and description of its bulk agent model and reasoning-effort selection capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->