### PR TITLE
Add paperclip-live-flow to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Extensions and integrations that add new capabilities to Paperclip.
 - [obsidian-paperclip](https://github.com/istib/obsidian-paperclip) - Obsidian plugin to browse, comment on, and assign Paperclip issues to AI agents.
 - [paperclip-aperture](https://github.com/tomismeta/paperclip-aperture) - Alternative Focus view for Paperclip that deterministically ranks approvals, issue activity, and other human-facing events into now, next, and ambient.
 - [paperclip-live-analytics-plugin](https://github.com/Agent-Analytics/paperclip-live-analytics-plugin) - Live visitor map, dashboard widget, and settings page for viewing Agent Analytics inside Paperclip.
+- [paperclip-live-flow](https://github.com/gloopsAI/paperclip-live-flow) - Read-only company and issue delivery visibility plugin for Paperclip ([release](https://github.com/gloopsAI/paperclip-live-flow/releases/tag/v0.1.0)).
 - [paperclip-plugin-acp](https://github.com/mvanhorn/paperclip-plugin-acp) - ACP runtime plugin that runs Claude Code, Codex, and Gemini CLI from any chat platform.
 - [paperclip-plugin-avp](https://github.com/creatorrmode-lead/paperclip-plugin-avp) — Trust and reputation layer via Agent Veil Protocol. DID identity, EigenTrust reputation, signed attestations. Adds trust gates before delegation and team reputation evaluation. [npm](https://www.npmjs.com/package/paperclip-plugin-avp)
 - [paperclip-plugin-chat](https://github.com/webprismdevin/paperclip-plugin-chat) - Interactive AI chat copilot for managing tasks, agents, and workspaces.


### PR DESCRIPTION
## Summary
Adds [gloopsAI/paperclip-live-flow](https://github.com/gloopsAI/paperclip-live-flow) under Plugins. It is a read-only Paperclip plugin for company/issue delivery visibility, released as `v0.1.0`.

## Test plan
- [x] Entry is alphabetically ordered in Plugins
- [x] Description is one sentence, starts with a capital letter, ends with a period
- [x] Repository and release links resolve

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `paperclip-live-flow` to the documented plugins list, including a link to its v0.1.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->